### PR TITLE
New Contact Links

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -72,11 +72,21 @@ block content
       .ui.fluid.card
         a.ui.attached.button(href="/contact") Get In Touch
         .content
-          h2.header ALL THE MEDIUMS.
           p.description
-            ul
-              li
-                a(href="https://twitter.com/DecentralizeAll") Twitter
-              li
-                a(href="https://plus.google.com/u/0/112799215242542928928/posts") Google+
+            | You can find our PGP keys and email addresses on <a href="/contact">our contact page</a>, or subscribe to us using your surveillance network of choice!
+                      
+          p.description
+            .twitter
+              h4 Follow us on Twitter! 
+                a(href="https://twitter.com/DecentralizeAll") @DecentralizeAll &raquo;
+              a.twitter-follow-button(href="https://twitter.com/DecentralizeAll", data-size="large", data-show-screen-name="false", data-show-count="true", data-lang="en") Follow @DecentralizeAll
+            .facebook
+              h4 Like us on Facebook! 
+                a(href="https://www.facebok.com/DecentralizeTheWorld") @DecentralizeTheWorld &raquo;
+              a.fb-like(href="https://www.facebok.com/DecentralizeTheWorld", data-href="https://developers.facebook.com/docs/plugins/", data-layout="button_count", data-action="recommend", data-show-faces="true", data-share="false") DECENTRALIZE on Facebook
+            .google(style="padding-top: 0.25em;")
+              h4 Follow us on Google! 
+                a(href="https://plus.google.com/112799215242542928928", data-rel="self") +DECENTRALIZE.fm &raquo;
+              a.g-follow(href="https://plus.google.com/112799215242542928928", data-href="https://plus.google.com/112799215242542928928", data-height="24", data-rel="publisher") DECENTRALIZE on Google
+
         a.ui.bottom.attached.button(href="/contact") Email Us &raquo;

--- a/views/layouts/default.jade
+++ b/views/layouts/default.jade
@@ -42,6 +42,8 @@ html.no-js
     base(href="/")
 
   body(ng-controller="mainController")
+    #fb-root
+
     .ui.page.grid
       .row
         block navbar
@@ -59,6 +61,9 @@ html.no-js
           //- stuff in footer?
             
     block scripts
+      
+      
+    script(src="https://apis.google.com/js/platform.js", async, defer)
 
     script.
       //- Twitter for Websites
@@ -78,7 +83,17 @@ html.no-js
        
         return t;
       }(document, "script", "twitter-wjs"));
-      
+
+      //- Facebook
+      (function(d, s, id) {
+        var js, fjs = d.getElementsByTagName(s)[0];
+        if (d.getElementById(id)) return;
+        js = d.createElement(s); js.id = id;
+        js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.3";
+        fjs.parentNode.insertBefore(js, fjs);
+      }(document, 'script', 'facebook-jssdk'));
+          
+
       //- Google Analytics
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
I've added a new version of the sidebar that includes an easier path and call to action for our social presence:

![example links](https://dl.dropbox.com/s/5bg963yp9d1u5um/Screenshot%202015-03-29%2022.17.04.png?dl=0)

I think this looks really clean, and it's about as semantic as it gets – even the plugins are properly formatted links that robots can read. :)