### PR TITLE
Add support for videos, where available.

### DIFF
--- a/decentralize.js
+++ b/decentralize.js
@@ -25,7 +25,9 @@ Show = decentralize.define('Show', {
     recorded: { type: Date },
     released: { type: Date , default: Date.now , required: true },
     description: { type: String },
-    audio: { type: String }
+    audio: { type: String },
+    // TODO: replace with a sources list.
+    youtube: { type: String }
   },
   names: { get: 'item' },
   source: source.proto + '://' + source.authority + '/recordings',

--- a/views/layouts/default.jade
+++ b/views/layouts/default.jade
@@ -61,6 +61,10 @@ html.no-js
     block scripts
 
     script.
+      $(window).on('ready', function() {
+        $('.ui.video').video();
+      });
+      
       //- Twitter for Websites
       window.twttr = (function(d, s, id) {
         var js, fjs = d.getElementsByTagName(s)[0],

--- a/views/show.jade
+++ b/views/show.jade
@@ -32,9 +32,17 @@ block scripts
 block content
   h1 #{ item.title }
 
-  p
-    include partials/viewer
+  if (item.youtube)
+    .ui.video(data-source="youtube", data-id="#{item.youtube}")
 
+    h2 Full Audio Show
+    p
+      include partials/viewer
+      
+  else
+    p
+      include partials/viewer
+      
   p
     .ui.buttons
       a.ui.button.tooltipped(href="//#{show.source.authority}/files/#{item.media}", title="Download the full mp3.")


### PR DESCRIPTION
This adds support for videos, when they're attached on decentral.fm.  See martindale/decentral.fm#3.