### PR TITLE
Add Sharing CTAs, Counts, on Show Pages

### DIFF
--- a/decentralize.js
+++ b/decentralize.js
@@ -13,7 +13,11 @@ var jsonpatch = require('fast-json-patch');
 var home = 'https://' + config.service.authority;
 
 var source = config.source;
-source.authority = source.host + (([80, 443].indexOf( parseInt(source.port) ) === -1) ? ':' + source.port : '');
+source.authority = source.host;
+if (!~[80, 443].indexOf( parseInt(source.port) )) {
+  source.authority += ':' + source.port;
+}
+source.base = source.proto + '://' + source.authority;
 
 var decentralize = new Maki( config );
 var soundcloud = new Soundcloud( config.soundcloud );
@@ -45,7 +49,7 @@ Index = decentralize.define('Index', {
   internal: true
 });
 
-procure( source.proto + '://' + source.authority + '/shows/decentralize', function(err, show) {
+procure( source.base + '/shows/decentralize' , function(err, show) {
   if (err) return console.error(err);
 
   // TODO: catch error

--- a/decentralize.js
+++ b/decentralize.js
@@ -46,6 +46,7 @@ Index = decentralize.define('Index', {
 });
 
 procure( source.proto + '://' + source.authority + '/shows/decentralize', function(err, show) {
+  if (err) return console.error(err);
 
   // TODO: catch error
   config.show = JSON.parse( show );

--- a/lib/Engine.js
+++ b/lib/Engine.js
@@ -76,14 +76,18 @@ Engine.prototype.sync = function( cb ) {
               Accept: 'application/json'
             }
           }, function(err, res) {
-            if (err) console.error(err);
+            if (err) return done( err );
+            
             res.resume();
             console.log('recording submitted', err , res.statusCode );
             return done( null , res.body );
           });
         });
 
-      }, cb );
+      }, function(err, results) {
+        if (err) console.error( err );
+        cb();
+      });
     });
   });
 }

--- a/views/show.jade
+++ b/views/show.jade
@@ -35,20 +35,30 @@ block content
   p
     include partials/viewer
 
-  p
-    .ui.buttons
-      a.ui.button.tooltipped(href="//#{show.source.authority}/files/#{item.media}", title="Download the full mp3.")
-        i.download.icon
-        | Download &raquo;
-      a.ui.button.tooltipped(href="//#{show.source.authority}/files/#{item.torrent}", title="Help distribute this content by using BitTorrent.")
-        i.cloud.download.icon
-        | Torrent &raquo;
-      a.ui.button.tooltipped(href="#{item.magnet}", title="Magnet URI for this file.")
-        i.magnet.icon
-        | Magnet &raquo;
-      a.ui.button.tooltipped(href="//#{show.source.authority}/files/#{item.media}.md5sum", title="Verify your copy of this file.")
-        i.lock.icon
-        | Verify &raquo;
+  .ui.two.column.centered.grid
+    .column
+      .ui.buttons
+        a.ui.button.tooltipped(href="//#{show.source.authority}/files/#{item.media}", title="Download the full mp3.")
+          i.download.icon
+          | Download &raquo;
+        a.ui.button.tooltipped(href="//#{show.source.authority}/files/#{item.torrent}", title="Help distribute this content by using BitTorrent.")
+          i.cloud.download.icon
+          | Torrent &raquo;
+        a.ui.button.tooltipped(href="#{item.magnet}", title="Magnet URI for this file.")
+          i.magnet.icon
+          | Magnet &raquo;
+        a.ui.button.tooltipped(href="//#{show.source.authority}/files/#{item.media}.md5sum", title="Verify your copy of this file.")
+          i.lock.icon
+          | Verify &raquo;
+
+    .column
+      .ui.three.column.grid
+        .column
+          a.g-plusone Share on Google &raquo;
+        .column
+          a.fb-like(href="https://www.facebook.com/sharer/sharer.php?u=#{show.home}/shows/#{show.slug}", data-width="200", data-href="#{show.home}/shows/#{show.slug}", data-layout="button_count", data-action="like", data-show-faces="false", data-share="false") Share on Facebook &raquo;
+        .column
+          a.twitter-share-button(href="#{show.home}/shows/#{show.slug}") Share on Twitter &raquo;
 
   p !{ markdown(item.description || '') }
 

--- a/views/show.jade
+++ b/views/show.jade
@@ -54,7 +54,7 @@ block content
     .column
       .ui.three.column.grid
         .column
-          a.g-plusone Share on Google &raquo;
+          a.g-plusone(href="https://plus.google.com/share?url=#{show.home}/shows/#{show.slug}") Share on Google &raquo;
         .column
           a.fb-like(href="https://www.facebook.com/sharer/sharer.php?u=#{show.home}/shows/#{show.slug}", data-width="200", data-href="#{show.home}/shows/#{show.slug}", data-layout="button_count", data-action="like", data-show-faces="false", data-share="false") Share on Facebook &raquo;
         .column


### PR DESCRIPTION
This adds the familiar sharing links below the embedded show on the dedicated show pages:

![example](https://dl.dropbox.com/s/upqtbeorwuqtlqg/Screenshot%202015-04-05%2022.17.27.png?dl=0)