### PR TITLE
Show Pages: Replace "Verify" with "Donate"

### DIFF
--- a/views/show.jade
+++ b/views/show.jade
@@ -47,9 +47,9 @@ block content
         a.ui.button.tooltipped(href="#{item.magnet}", title="Magnet URI for this file.")
           i.magnet.icon
           | Magnet &raquo;
-        a.ui.button.tooltipped(href="//#{show.source.authority}/files/#{item.media}.md5sum", title="Verify your copy of this file.")
-          i.lock.icon
-          | Verify &raquo;
+        a.ui.button.tooltipped(href="bitcoin:#{ show.donations.destination }", title="If you have a bitcoin wallet installed and configured, this will launch it.") 
+          i.icon.bitcoin(alt="Bitoin", title="Donate Bitcoin")
+          | Donate &raquo;
 
     .column
       .ui.three.column.grid


### PR DESCRIPTION
Since there's already instructions on verifying, I'm replacing the verify button with a link to donate.

@jameswalpole this is ready to merge as is, but this would be a good area for you to improve upon in the future!