### PR TITLE
Fix Engine Sync

### DIFF
--- a/decentralize.js
+++ b/decentralize.js
@@ -108,7 +108,7 @@ procure( source.base + '/shows/decentralize' , function(err, show) {
     var engine = new Engine( config , decentralize );
 
     setInterval(function() {
-      //engine.sync();
+      engine.sync();
     }, /*/ 2500 /*/ 1 * 3600 * 1000 /**/ );
 
     engine.subscribe();

--- a/lib/Engine.js
+++ b/lib/Engine.js
@@ -102,7 +102,19 @@ Engine.prototype.sync = function( cb ) {
           if (e.slug == track.permalink) return true;
           return false;
         });
-        if (episode) return done( null , episode );
+        if (episode) {
+          request.patch({
+            url: 'https://' + self.config.source.authority + '/recordings/' + episode.slug
+            data: {
+              soundcloud: track.id,
+              type: 'soundcloud'
+            }
+          }, function(err, res, body) {
+            if (err) console.error(err);
+            console.log('patch request for ' + episode.slug , res.statusCode );
+          });
+          return done( null , episode );
+        }
 
         if (!track.download_url) return console.log('track not downloadable:' , track.title );
         console.log('no episode found on decentral.fm for show: "'+track.title+'"!  initiating upload...');

--- a/lib/Engine.js
+++ b/lib/Engine.js
@@ -105,7 +105,8 @@ Engine.prototype.sync = function( cb ) {
         if (episode) {
           request.patch({
             url: 'https://' + self.config.source.authority + '/recordings/' + episode.slug,
-            data: {
+            json: true,
+            body: {
               soundcloud: track.id,
               type: 'soundcloud'
             }

--- a/lib/Engine.js
+++ b/lib/Engine.js
@@ -104,7 +104,7 @@ Engine.prototype.sync = function( cb ) {
         });
         if (episode) {
           request.patch({
-            url: 'https://' + self.config.source.authority + '/recordings/' + episode.slug
+            url: 'https://' + self.config.source.authority + '/recordings/' + episode.slug,
             data: {
               soundcloud: track.id,
               type: 'soundcloud'


### PR DESCRIPTION
This replaces the "remotes" list (a feature for future use) with a basic top-level element, which already existed for the YouTube remote – but specifically for Soundcloud, this resolves most issues with syncing, as we have now changed the filter logic to require one less round trip, and correctly track the Soundcloud track ID on the model.