### PR TITLE
Header Spacing

### DIFF
--- a/views/partials/navbar.jade
+++ b/views/partials/navbar.jade
@@ -1,7 +1,7 @@
 .ui.main.tiered.menu.large
   .menu
     a.item(href="/", title="#{config.service.name} THE PODCAST")
-      img(src="/img/decentralize-emblem.gif", style="max-height: 2em; float:left;", alt="D")
+      img(src="/img/decentralize-emblem.gif", style="max-height: 2em; float:left; margin-right: 0.1em;", alt="D")
       | #{config.service.name.substring(1)}
       span(style="display:block; font-size: 0.8em; letter-spacing: 0.1285em;") THE PODCAST
 


### PR DESCRIPTION
This fixes our header from this: ![before](https://dl.dropbox.com/s/4631dd4v1ou3pre/Screenshot%202015-07-27%2015.11.33.png?dl=0) to this: ![after](https://dl.dropbox.com/s/fwbv7zag0kcz47c/Screenshot%202015-07-27%2015.13.41.png?dl=0).  I thought I did this before, but it's tidier now.